### PR TITLE
Added flag to output JSON

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -38,7 +38,7 @@ try {
       clean({
         patterns: ['./dist/*'],
       }),
-      environmentPlugin(['npm_package_engines_node']),
+      environmentPlugin(['npm_package_name']),
     ],
   });
 

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   },
   "packageManager": "pnpm@8.15.5+sha256.4b4efa12490e5055d59b9b9fc9438b7d581a6b7af3b5675eb5c5f447cee1a589",
   "scripts": {
-    "predemo": "pnpm build:dev",
-    "demo": "./dist/cli.mjs",
+    "prevalidate": "pnpm build:dev",
+    "validate": "./dist/cli.mjs",
     "format": "prettier --write .",
     "build": "cross-env NODE_ENV=production node --experimental-json-modules --no-warnings ./build.mjs",
     "build:dev": "cross-env NODE_ENV=development node --experimental-json-modules --no-warnings ./build.mjs",

--- a/readme.md
+++ b/readme.md
@@ -20,16 +20,24 @@ yarn add validate-package-exports -D
 
 ## Options
 
-| Flag | Description | Default value | Required |
-| --- | --- | --- | --- |
-| `--package` / `-p` | Path to `package.json` file | `[cwd]/package.json` | :white_check_mark: |
-| `--check` / `-s` | Check syntax of JS files | `false` |  |
-| `--verify` / `-v` | Verify a module can be imported or required | `false` |  |
-| `--concurrency` / `-c` | Concurrency | `availableParallelism()` |  |
-| `--bail` / `-b` | Bail | `process.env.CI === 'true'` |  |
-| `--logLevel` / `-l` | Log level | `info` |  |
+| Flag | Description | Default value |
+| --- | --- | --- |
+| `--check` / `-s` | Check syntax of JS files | `false` |
+| `--verify` / `-v` | Verify a module can be imported or required | `false` |
+| `--concurrency` / `-c` | Concurrency | `availableParallelism()` |
+| `--bail` / `-b` | Bail | `process.env.CI === 'true'` |
+| `--info` / `-j` | Show `info` messages.<br>The default behavior is to only show `error`. | `process.env.RUNNER_DEBUG === '1'` |
+| `--json` / `-j` | Use JSON output | `false` |
 
-## Recommended usage
+## Usage
+
+```sh
+validate-package-exports [FILE]... [options]
+```
+
+:information_source: If you do not provide a path to a `package.json`, it will try to find one in the current directory.
+
+### Package scripts examples
 
 ```json
 {
@@ -48,6 +56,12 @@ OR
     "prepublishOnly": "validate-package-exports --check --verify"
   }
 }
+```
+
+### Using `npx`
+
+```shell
+npx --yes validate-package-exports ./path/to/package.json --check --verify
 ```
 
 ## Local development

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ yarn add validate-package-exports -D
 | `--verify` / `-v` | Verify a module can be imported or required | `false` |
 | `--concurrency` / `-c` | Concurrency | `availableParallelism()` |
 | `--bail` / `-b` | Bail | `process.env.CI === 'true'` |
-| `--info` / `-j` | Show `info` messages.<br>The default behavior is to only show `error`. | `process.env.RUNNER_DEBUG === '1'` |
+| `--info` / `-i` | Show `info` messages.<br>The default behavior is to only show `error`. | `process.env.RUNNER_DEBUG === '1'` |
 | `--json` / `-j` | Use JSON output | `false` |
 
 ## Usage

--- a/src/lib/ExportsProcessor.test.ts
+++ b/src/lib/ExportsProcessor.test.ts
@@ -100,11 +100,11 @@ describe('ExportsProcessor', () => {
         packageContext,
       );
 
-      expect(entryPoints).toEqual([
+      expect(entryPoints).toEqual<EntryPoint[]>([
         {
           condition: 'default',
           type: demoPackageJson.type,
-          packageContext,
+          packagePath: packageContext.path,
           moduleName: demoPackageJson.name,
           relativePath: 'index.js',
           resolvedPath: resolve('/tmp/index.js'),
@@ -115,7 +115,7 @@ describe('ExportsProcessor', () => {
         },
         {
           type: demoPackageJson.type,
-          packageContext,
+          packagePath: packageContext.path,
           moduleName: demoPackageJson.name,
           relativePath: 'index.js',
           resolvedPath: resolve('/tmp/index.js'),
@@ -127,7 +127,7 @@ describe('ExportsProcessor', () => {
         },
         {
           type: demoPackageJson.type,
-          packageContext,
+          packagePath: packageContext.path,
           moduleName: `${demoPackageJson.name}/package.json`,
           relativePath: 'package.json',
           resolvedPath: resolve('/tmp/package.json'),
@@ -137,7 +137,7 @@ describe('ExportsProcessor', () => {
           condition: undefined,
           itemPath: ['exports', './package.json'],
         },
-      ] satisfies EntryPoint[]);
+      ]);
     });
 
     it('Works with ConditionalExports', () => {
@@ -167,10 +167,10 @@ describe('ExportsProcessor', () => {
         packageContext,
       );
 
-      expect(entryPoints).toEqual([
+      expect(entryPoints).toEqual<EntryPoint[]>([
         {
           moduleName: 'demo',
-          packageContext,
+          packagePath: packageContext.path,
           type: 'commonjs',
           fileName: 'index.d.ts',
           relativePath: fixSlash('dist/types/index.d.ts'),
@@ -182,7 +182,7 @@ describe('ExportsProcessor', () => {
         },
         {
           moduleName: 'demo',
-          packageContext,
+          packagePath: packageContext.path,
           type: 'commonjs',
           fileName: 'index.js',
           relativePath: fixSlash('dist/cjs/index.js'),
@@ -194,7 +194,7 @@ describe('ExportsProcessor', () => {
         },
         {
           moduleName: 'demo',
-          packageContext,
+          packagePath: packageContext.path,
           type: 'module',
           fileName: 'index.js',
           relativePath: fixSlash('dist/mjs/index.js'),
@@ -252,10 +252,10 @@ describe('ExportsProcessor', () => {
         packageContext,
       );
 
-      expect(entryPoints).toEqual([
+      expect(entryPoints).toEqual<EntryPoint[]>([
         {
           type: 'commonjs',
-          packageContext,
+          packagePath: packageContext.path,
           condition: 'types',
           moduleName: demoPackageJson.name,
           relativePath: fixSlash('dist/types/index.d.ts'),
@@ -267,7 +267,7 @@ describe('ExportsProcessor', () => {
         },
         {
           type: 'commonjs',
-          packageContext,
+          packagePath: packageContext.path,
           condition: 'require',
           moduleName: demoPackageJson.name,
           relativePath: fixSlash('dist/cjs/index.js'),
@@ -279,7 +279,7 @@ describe('ExportsProcessor', () => {
         },
         {
           type: 'module',
-          packageContext,
+          packagePath: packageContext.path,
           condition: 'import',
           moduleName: demoPackageJson.name,
           relativePath: fixSlash('dist/mjs/index.js'),
@@ -291,7 +291,7 @@ describe('ExportsProcessor', () => {
         },
         {
           type: 'commonjs',
-          packageContext,
+          packagePath: packageContext.path,
           condition: 'types',
           moduleName: `${demoPackageJson.name}/*`,
           relativePath: fixSlash('dist/types/*.d.ts'),
@@ -303,7 +303,7 @@ describe('ExportsProcessor', () => {
         },
         {
           type: 'commonjs',
-          packageContext,
+          packagePath: packageContext.path,
           condition: 'require',
           moduleName: `${demoPackageJson.name}/*`,
           relativePath: fixSlash('dist/cjs/*.js'),
@@ -315,7 +315,7 @@ describe('ExportsProcessor', () => {
         },
         {
           type: 'module',
-          packageContext,
+          packagePath: packageContext.path,
           condition: 'import',
           moduleName: `${demoPackageJson.name}/*`,
           relativePath: fixSlash('dist/mjs/*.js'),
@@ -327,7 +327,7 @@ describe('ExportsProcessor', () => {
         },
         {
           type: 'commonjs',
-          packageContext,
+          packagePath: packageContext.path,
           condition: 'types',
           moduleName: `${demoPackageJson.name}/sub-folder/*`,
           relativePath: fixSlash('dist/types/sub-folder/*.d.ts'),
@@ -339,7 +339,7 @@ describe('ExportsProcessor', () => {
         },
         {
           type: 'commonjs',
-          packageContext,
+          packagePath: packageContext.path,
           condition: 'require',
           moduleName: `${demoPackageJson.name}/sub-folder/*`,
           relativePath: fixSlash('dist/cjs/sub-folder/*.js'),
@@ -351,7 +351,7 @@ describe('ExportsProcessor', () => {
         },
         {
           type: 'commonjs',
-          packageContext,
+          packagePath: packageContext.path,
           condition: 'types',
           moduleName: `${demoPackageJson.name}/sub-folder/*`,
           relativePath: fixSlash('dist/types/sub-folder/*.d.ts'),
@@ -363,7 +363,7 @@ describe('ExportsProcessor', () => {
         },
         {
           type: 'module',
-          packageContext,
+          packagePath: packageContext.path,
           condition: 'import',
           moduleName: `${demoPackageJson.name}/sub-folder/*`,
           relativePath: fixSlash('dist/mjs/sub-folder/*.js'),
@@ -375,7 +375,7 @@ describe('ExportsProcessor', () => {
         },
         {
           type: 'commonjs',
-          packageContext,
+          packagePath: packageContext.path,
           condition: undefined,
           moduleName: `${demoPackageJson.name}/package.json`,
           relativePath: fixSlash('package.json'),

--- a/src/lib/ExportsProcessor.test.ts
+++ b/src/lib/ExportsProcessor.test.ts
@@ -25,8 +25,8 @@ describe('ExportsProcessor', () => {
       const packageContext: PackageContext = {
         name: demoPackageJson.name,
         type: demoPackageJson.type as PackageType,
-        path: '/tmp/package.json',
-        directory: '/tmp',
+        path: resolve('/tmp/package.json'),
+        directory: resolve('/tmp'),
       };
 
       expect(
@@ -52,8 +52,8 @@ describe('ExportsProcessor', () => {
       const packageContext: PackageContext = {
         name: demoPackageJson.name,
         type: demoPackageJson.type,
-        path: '/tmp/package.json',
-        directory: '/tmp',
+        path: resolve('/tmp/package.json'),
+        directory: resolve('/tmp'),
       };
 
       expect(
@@ -87,8 +87,8 @@ describe('ExportsProcessor', () => {
       const packageContext: PackageContext = {
         name: demoPackageJson.name,
         type: demoPackageJson.type,
-        path: '/tmp/package.json',
-        directory: '/tmp',
+        path: resolve('/tmp/package.json'),
+        directory: resolve('/tmp'),
       };
 
       const entryPoints = new ExportsProcessor().process(
@@ -106,7 +106,7 @@ describe('ExportsProcessor', () => {
           type: demoPackageJson.type,
           packageContext,
           moduleName: demoPackageJson.name,
-          relativePath: fixSlash('index.js'),
+          relativePath: 'index.js',
           resolvedPath: resolve('/tmp/index.js'),
           fileName: 'index.js',
           directory: resolve('/tmp'),
@@ -117,7 +117,7 @@ describe('ExportsProcessor', () => {
           type: demoPackageJson.type,
           packageContext,
           moduleName: demoPackageJson.name,
-          relativePath: fixSlash('index.js'),
+          relativePath: 'index.js',
           resolvedPath: resolve('/tmp/index.js'),
           fileName: 'index.js',
           directory: resolve('/tmp'),
@@ -129,7 +129,7 @@ describe('ExportsProcessor', () => {
           type: demoPackageJson.type,
           packageContext,
           moduleName: `${demoPackageJson.name}/package.json`,
-          relativePath: fixSlash('package.json'),
+          relativePath: 'package.json',
           resolvedPath: resolve('/tmp/package.json'),
           fileName: 'package.json',
           directory: resolve('/tmp'),
@@ -155,8 +155,8 @@ describe('ExportsProcessor', () => {
       const packageContext: PackageContext = {
         name: demoPackageJson.name,
         type: demoPackageJson.type,
-        path: '/tmp/package.json',
-        directory: '/tmp',
+        path: resolve('/tmp/package.json'),
+        directory: resolve('/tmp'),
       };
 
       const entryPoints = new ExportsProcessor().process(
@@ -173,9 +173,9 @@ describe('ExportsProcessor', () => {
           packageContext,
           type: 'commonjs',
           fileName: 'index.d.ts',
-          relativePath: 'dist/types/index.d.ts',
-          directory: '/tmp/dist/types',
-          resolvedPath: '/tmp/dist/types/index.d.ts',
+          relativePath: fixSlash('dist/types/index.d.ts'),
+          directory: resolve('/tmp/dist/types'),
+          resolvedPath: resolve('/tmp/dist/types/index.d.ts'),
           subpath: '.',
           condition: 'types',
           itemPath: ['exports', 'types'],
@@ -185,9 +185,9 @@ describe('ExportsProcessor', () => {
           packageContext,
           type: 'commonjs',
           fileName: 'index.js',
-          relativePath: 'dist/cjs/index.js',
-          directory: '/tmp/dist/cjs',
-          resolvedPath: '/tmp/dist/cjs/index.js',
+          relativePath: fixSlash('dist/cjs/index.js'),
+          directory: resolve('/tmp/dist/cjs'),
+          resolvedPath: resolve('/tmp/dist/cjs/index.js'),
           subpath: '.',
           condition: 'require',
           itemPath: ['exports', 'require'],
@@ -197,9 +197,9 @@ describe('ExportsProcessor', () => {
           packageContext,
           type: 'module',
           fileName: 'index.js',
-          relativePath: 'dist/mjs/index.js',
-          directory: '/tmp/dist/mjs',
-          resolvedPath: '/tmp/dist/mjs/index.js',
+          relativePath: fixSlash('dist/mjs/index.js'),
+          directory: resolve('/tmp/dist/mjs'),
+          resolvedPath: resolve('/tmp/dist/mjs/index.js'),
           subpath: '.',
           condition: 'import',
           itemPath: ['exports', 'import'],
@@ -240,8 +240,8 @@ describe('ExportsProcessor', () => {
       const packageContext: PackageContext = {
         name: demoPackageJson.name,
         type: demoPackageJson.type,
-        path: '/tmp/package.json',
-        directory: '/tmp',
+        path: resolve('/tmp/package.json'),
+        directory: resolve('/tmp'),
       };
 
       const entryPoints = new ExportsProcessor().process(

--- a/src/lib/Result.ts
+++ b/src/lib/Result.ts
@@ -1,0 +1,47 @@
+import type { EntryPoint } from '@src/types.js';
+
+export type ResultName = 'check-syntax' | 'file-exists' | 'require' | 'import';
+
+export const enum ResultCode {
+  Success,
+  Error,
+  Skip,
+}
+
+export type ResultDetails = {
+  name: ResultName;
+  code: ResultCode;
+  message: string;
+  entryPoint: EntryPoint;
+  error?: Error;
+};
+
+export class Result {
+  name: ResultName;
+
+  code: ResultCode;
+
+  message: string;
+
+  entryPoint: EntryPoint;
+
+  error: Error | undefined;
+
+  constructor(details: ResultDetails) {
+    this.name = details.name;
+    this.code = details.code;
+    this.message = details.message;
+    this.entryPoint = details.entryPoint;
+    this.error = details.error;
+  }
+
+  toString(): string {
+    const emoji = this.code === ResultCode.Success ? '✅' : this.code === ResultCode.Error ? '❌' : '😐';
+
+    if (this.code === ResultCode.Error) {
+      return `${emoji} ${this.name}: ${this.message} (${JSON.stringify(this.entryPoint.itemPath)}) ${this.error ?? ''}`.trim();
+    } else {
+      return `${emoji} ${this.name}: ${this.message}`;
+    }
+  }
+}

--- a/src/lib/Validator.ts
+++ b/src/lib/Validator.ts
@@ -1,4 +1,4 @@
-import { setMaxListeners, EventEmitter } from 'node:events';
+import { EventEmitter } from 'node:events';
 import { dirname } from 'node:path';
 import { Readable } from 'node:stream';
 
@@ -29,9 +29,7 @@ export class Validator extends EventEmitter {
 
     this.#exitCode = ExitCode.Ok;
 
-    this.#controller = new AbortController();
-
-    setMaxListeners(100, this.#controller.signal);
+    this.#controller = options.controller;
   }
 
   protected processResult(result: Result): void {

--- a/src/lib/Validator.ts
+++ b/src/lib/Validator.ts
@@ -1,18 +1,18 @@
-import { setMaxListeners } from 'node:events';
+import { setMaxListeners, EventEmitter } from 'node:events';
 import { dirname } from 'node:path';
 import { Readable } from 'node:stream';
 
-import { ExitCode, ResultCode, type EntryPoint, type Result, type ValidatePackageExportsOptions } from '@src/types.js';
+import { ExitCode, type EntryPoint, type PackageContext, type ValidatorOptions } from '@src/types.js';
 import { checkFileExists } from '@utils/checkFileExists.js';
 import { checkSyntax } from '@utils/checkSyntax.js';
 import { getEntryPoints } from '@utils/getEntryPoints.js';
 import { importPackageJson } from '@utils/importPackageJson.js';
 import { verifyEntryPoint } from '@utils/verifyEntryPoint.js';
 
-import type { Logger } from './Logger.js';
+import { ResultCode, type Result } from './Result.js';
 
-export class Validator {
-  options: ValidatePackageExportsOptions;
+export class Validator extends EventEmitter {
+  options: ValidatorOptions;
 
   packageDirectory: string;
 
@@ -20,14 +20,12 @@ export class Validator {
 
   #controller: AbortController;
 
-  protected readonly logger: Logger;
+  constructor(options: ValidatorOptions) {
+    super();
 
-  constructor(options: ValidatePackageExportsOptions, logger: Logger) {
     this.options = options;
 
     this.packageDirectory = dirname(this.options.package);
-
-    this.logger = logger;
 
     this.#exitCode = ExitCode.Ok;
 
@@ -37,6 +35,8 @@ export class Validator {
   }
 
   protected processResult(result: Result): void {
+    this.emit('result', result);
+
     if (result.code === ResultCode.Error) {
       this.#exitCode = ExitCode.Error;
 
@@ -44,38 +44,13 @@ export class Validator {
         this.#controller.abort();
       }
     }
-
-    const emoji = result.code === ResultCode.Success ? '✅' : result.code === ResultCode.Error ? '❌' : '😐';
-
-    if (result.code === ResultCode.Error) {
-      this.logger.error(`${emoji} ${result.name}: ${result.message} (${JSON.stringify(result.entryPoint.itemPath)})`);
-      this.logger.error(result.error);
-    } else {
-      this.logger.info(`${emoji} ${result.name}: ${result.message}`);
-    }
   }
 
   protected processResults(results: Result | Result[]): void {
     [results].flat().forEach(result => this.processResult(result));
   }
 
-  async run(): Promise<ExitCode> {
-    const packageJson = await importPackageJson(this.options.package);
-
-    this.logger.debug(`📂 package directory: ${this.packageDirectory}`);
-
-    this.logger.debug({
-      options: this.options,
-      packageJson,
-    });
-
-    const entryPoints: EntryPoint[] = await Readable.from(getEntryPoints(packageJson, this.packageDirectory), {
-      objectMode: true,
-    }).toArray({
-      signal: this.#controller.signal,
-    });
-
-    // Always check to see if the file exists.
+  protected async checkFilesExist(entryPoints: EntryPoint[]): Promise<void> {
     await Readable.from(entryPoints).forEach(
       async (entryPoint: EntryPoint) => {
         const results = await checkFileExists(entryPoint);
@@ -87,40 +62,68 @@ export class Validator {
         concurrency: this.options.concurrency,
       },
     );
+  }
+
+  protected async checkSyntax(entryPoints: EntryPoint[]): Promise<void> {
+    const jsEntryPoints = entryPoints.filter(entryPoint => /\.[cm]?js$/i.test(entryPoint.resolvedPath));
+
+    await Readable.from(jsEntryPoints).forEach(
+      async (entryPoint: EntryPoint) => {
+        const results = await checkSyntax(entryPoint, { signal: this.#controller.signal });
+
+        this.processResults(results);
+      },
+      {
+        signal: this.#controller.signal,
+        concurrency: this.options.concurrency,
+      },
+    );
+  }
+
+  protected async verifyIncludes(entryPoints: EntryPoint[]): Promise<void> {
+    await Readable.from(entryPoints).forEach(
+      async (entryPoint: EntryPoint) => {
+        const results = await verifyEntryPoint(entryPoint, {
+          cwd: this.packageDirectory,
+          signal: this.#controller.signal,
+        });
+
+        this.processResults(results);
+      },
+      {
+        signal: this.#controller.signal,
+        concurrency: this.options.concurrency,
+      },
+    );
+  }
+
+  async run(): Promise<ExitCode> {
+    const packageJson = await importPackageJson(this.options.package);
+
+    const packageContext: PackageContext = {
+      name: packageJson.name,
+      type: packageJson.type ?? 'commonjs',
+      path: this.options.package,
+      directory: this.packageDirectory,
+    };
+
+    const entryPoints: EntryPoint[] = await Readable.from(getEntryPoints(packageJson, packageContext), {
+      objectMode: true,
+    }).toArray({
+      signal: this.#controller.signal,
+    });
+
+    // Always check to see if the file exists.
+    await this.checkFilesExist(entryPoints);
 
     // Optionally run a syntax check.
     if (this.options.check) {
-      const jsEntryPoints = entryPoints.filter(entryPoint => /\.[cm]?js$/i.test(entryPoint.resolvedPath));
-
-      await Readable.from(jsEntryPoints).forEach(
-        async (entryPoint: EntryPoint) => {
-          const results = await checkSyntax(entryPoint, { signal: this.#controller.signal });
-
-          this.processResults(results);
-        },
-        {
-          signal: this.#controller.signal,
-          concurrency: this.options.concurrency,
-        },
-      );
+      await this.checkSyntax(entryPoints);
     }
 
     // Optionally try to `import`/`require` the module.
     if (this.options.verify) {
-      await Readable.from(entryPoints).forEach(
-        async (entryPoint: EntryPoint) => {
-          const results = await verifyEntryPoint(entryPoint, {
-            cwd: this.packageDirectory,
-            signal: this.#controller.signal,
-          });
-
-          this.processResults(results);
-        },
-        {
-          signal: this.#controller.signal,
-          concurrency: this.options.concurrency,
-        },
-      );
+      await this.verifyIncludes(entryPoints);
     }
 
     return this.#exitCode;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,6 @@ import type { UnknownRecord } from '@webdeveric/utils/types/records';
 export enum ExitCode {
   Ok = 0,
   Error,
-  UnableToVerify,
 }
 
 export type LogLevelName = 'emergency' | 'alert' | 'critical' | 'error' | 'warning' | 'notice' | 'info' | 'debug';
@@ -33,13 +32,17 @@ export const logLevelMapping: Record<LogLevelName, LogLevel> = {
   debug: LogLevel.Debug,
 };
 
-export type ValidatePackageExportsOptions = {
-  package: string;
+export type CliArguments = {
+  packages: string[];
   bail: boolean;
   check: boolean;
   verify: boolean;
   concurrency: number;
+  json: boolean;
+  info: boolean;
 };
+
+export type ValidatorOptions = Pick<CliArguments, 'bail' | 'check' | 'verify' | 'concurrency'> & { package: string };
 
 export type MaybeUndefined<Type> = Type extends UnknownRecord
   ? {
@@ -125,7 +128,15 @@ export type PackageJson = {
 
 export type ItemPath = (string | number)[];
 
+export type PackageContext = Readonly<{
+  name: string;
+  type: PackageType;
+  path: string;
+  directory: string;
+}>;
+
 export type EntryPoint = {
+  packageContext: PackageContext;
   // bin scripts will not have this
   moduleName: string | undefined; // This is string used with `require` or `import`.
   type: PackageType;
@@ -142,28 +153,3 @@ export type ResolvedEntryPoint = EntryPoint & {
   realResolvedPath: string;
   realDirectory: string;
 };
-
-export type ResultName = 'check-syntax' | 'file-exists' | 'require' | 'import';
-
-export const enum ResultCode {
-  Success,
-  Error,
-  Skip,
-}
-
-export type GoodResult = {
-  code: ResultCode.Success | ResultCode.Skip;
-  entryPoint: EntryPoint;
-  message: string;
-  name: ResultName;
-};
-
-export type BadResult = {
-  code: ResultCode.Error;
-  entryPoint: EntryPoint;
-  error: Error;
-  message: string;
-  name: ResultName;
-};
-
-export type Result = GoodResult | BadResult;

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,7 +42,10 @@ export type CliArguments = {
   info: boolean;
 };
 
-export type ValidatorOptions = Pick<CliArguments, 'bail' | 'check' | 'verify' | 'concurrency'> & { package: string };
+export type ValidatorOptions = Pick<CliArguments, 'bail' | 'check' | 'verify' | 'concurrency'> & {
+  package: string;
+  controller: AbortController;
+};
 
 export type MaybeUndefined<Type> = Type extends UnknownRecord
   ? {
@@ -136,7 +139,7 @@ export type PackageContext = Readonly<{
 }>;
 
 export type EntryPoint = {
-  packageContext: PackageContext;
+  packagePath: PackageContext['path'];
   // bin scripts will not have this
   moduleName: string | undefined; // This is string used with `require` or `import`.
   type: PackageType;

--- a/src/utils/checkFileExists.ts
+++ b/src/utils/checkFileExists.ts
@@ -1,6 +1,7 @@
 import { relative } from 'node:path';
 
-import { ResultCode, type EntryPoint, type Result } from '@src/types.js';
+import { Result, ResultCode } from '@lib/Result.js';
+import type { EntryPoint } from '@src/types.js';
 
 import { isFile } from './isFile.js';
 
@@ -10,19 +11,19 @@ export async function checkFileExists(entryPoint: EntryPoint): Promise<Result> {
       throw new Error(`${entryPoint.resolvedPath} is not a file`);
     }
 
-    return {
+    return new Result({
       name: 'file-exists',
       code: ResultCode.Success,
-      message: relative(process.cwd(), entryPoint.resolvedPath),
+      message: `${relative(process.cwd(), entryPoint.resolvedPath)} exists`,
       entryPoint,
-    };
+    });
   } catch (error) {
-    return {
+    return new Result({
       name: 'file-exists',
       code: ResultCode.Error,
       entryPoint,
-      message: relative(process.cwd(), entryPoint.resolvedPath),
+      message: `${relative(process.cwd(), entryPoint.resolvedPath)} does not exist`,
       error: error instanceof Error ? error : new Error(String(error)),
-    };
+    });
   }
 }

--- a/src/utils/checkImport.ts
+++ b/src/utils/checkImport.ts
@@ -1,4 +1,5 @@
-import { type EntryPoint, type Result, ResultCode } from '@src/types.js';
+import { Result, ResultCode } from '@lib/Result.js';
+import type { EntryPoint } from '@src/types.js';
 
 import { execImport } from './execImport.js';
 
@@ -9,27 +10,27 @@ export async function checkImport(entryPoint: EntryPoint, options: ExecOptions):
     if (typeof entryPoint.moduleName === 'string') {
       await execImport(entryPoint.moduleName, options);
 
-      return {
+      return new Result({
         code: ResultCode.Success,
         entryPoint,
-        message: entryPoint.moduleName,
+        message: `"${entryPoint.moduleName}" works with import`,
         name: 'import',
-      };
+      });
     }
 
-    return {
+    return new Result({
       code: ResultCode.Skip,
       entryPoint,
       message: `Import skipped: ${entryPoint.itemPath.join('.')}`,
       name: 'import',
-    };
+    });
   } catch (error) {
-    return {
+    return new Result({
       code: ResultCode.Error,
       entryPoint,
       error: error instanceof Error ? error : new Error(String(error)),
       message: `${entryPoint.moduleName ?? entryPoint.itemPath.join('.')} cannot be imported`,
       name: 'import',
-    };
+    });
   }
 }

--- a/src/utils/checkRequire.ts
+++ b/src/utils/checkRequire.ts
@@ -1,4 +1,5 @@
-import { type EntryPoint, type Result, ResultCode } from '@src/types.js';
+import { Result, ResultCode } from '@lib/Result.js';
+import type { EntryPoint } from '@src/types.js';
 
 import { execRequire } from './execRequire.js';
 
@@ -9,27 +10,27 @@ export async function checkRequire(entryPoint: EntryPoint, options: ExecOptions)
     if (typeof entryPoint.moduleName === 'string') {
       await execRequire(entryPoint.moduleName, options);
 
-      return {
+      return new Result({
         code: ResultCode.Success,
         entryPoint,
-        message: entryPoint.moduleName,
+        message: `"${entryPoint.moduleName}" works with require`,
         name: 'require',
-      };
+      });
     }
 
-    return {
+    return new Result({
       code: ResultCode.Skip,
       entryPoint,
       message: `Require skipped: ${entryPoint.itemPath.join('.')}`,
       name: 'require',
-    };
+    });
   } catch (error) {
-    return {
+    return new Result({
       code: ResultCode.Error,
       entryPoint,
       error: error instanceof Error ? error : new Error(String(error)),
       message: `${entryPoint.moduleName ?? entryPoint.itemPath.join('.')} cannot be required`,
       name: 'require',
-    };
+    });
   }
 }

--- a/src/utils/checkSyntax.ts
+++ b/src/utils/checkSyntax.ts
@@ -1,6 +1,7 @@
 import { relative } from 'node:path';
 
-import { type Result, ResultCode, type EntryPoint } from '@src/types.js';
+import { Result, ResultCode } from '@lib/Result.js';
+import type { EntryPoint } from '@src/types.js';
 
 import { asyncExec } from './asyncExec.js';
 
@@ -10,19 +11,19 @@ export async function checkSyntax(entryPoint: EntryPoint, options: ExecOptions):
   try {
     await asyncExec(`node --check ${entryPoint.resolvedPath}`, options);
 
-    return {
+    return new Result({
       code: ResultCode.Success,
       entryPoint,
-      message: relative(process.cwd(), entryPoint.resolvedPath),
+      message: `${relative(process.cwd(), entryPoint.resolvedPath)} has valid syntax`,
       name: 'check-syntax',
-    };
+    });
   } catch (error) {
-    return {
+    return new Result({
       code: ResultCode.Error,
       entryPoint,
       error: error instanceof Error ? error : new Error(String(error)),
-      message: relative(process.cwd(), entryPoint.resolvedPath),
+      message: `Could not validate syntax for ${relative(process.cwd(), entryPoint.resolvedPath)}`,
       name: 'check-syntax',
-    };
+    });
   }
 }

--- a/src/utils/createEntryPoint.ts
+++ b/src/utils/createEntryPoint.ts
@@ -1,14 +1,13 @@
 import { relative, dirname, basename, resolve } from 'node:path';
 
-import type { PackageType, EntryPoint, ItemPath } from '@src/types.js';
+import type { PackageType, EntryPoint, ItemPath, PackageContext } from '@src/types.js';
 
 import { getModuleName } from './getModuleName.js';
 import { getModuleType } from './getModuleType.js';
 
 export type CreateEntryPointOptions = {
   modulePath: string;
-  packageDirectory: string;
-  packageName: string;
+  packageContext: PackageContext;
   packageType?: PackageType | undefined;
   subpath: string | undefined;
   itemPath: ItemPath;
@@ -19,18 +18,17 @@ export function createEntryPoint({
   condition,
   itemPath,
   modulePath,
-  packageDirectory,
-  packageName,
-  packageType = 'commonjs',
+  packageContext,
   subpath,
 }: CreateEntryPointOptions): EntryPoint {
-  const resolvedPath = resolve(packageDirectory, modulePath);
+  const resolvedPath = resolve(packageContext.directory, modulePath);
 
   return {
-    moduleName: subpath ? getModuleName(packageName, subpath) : undefined,
-    type: getModuleType(modulePath, packageType, condition),
+    moduleName: subpath ? getModuleName(packageContext.name, subpath) : undefined,
+    packageContext,
+    type: getModuleType(modulePath, packageContext.type, condition),
     fileName: basename(resolvedPath),
-    relativePath: relative(packageDirectory, resolvedPath),
+    relativePath: relative(packageContext.directory, resolvedPath),
     directory: dirname(resolvedPath),
     resolvedPath,
     subpath,

--- a/src/utils/createEntryPoint.ts
+++ b/src/utils/createEntryPoint.ts
@@ -25,7 +25,7 @@ export function createEntryPoint({
 
   return {
     moduleName: subpath ? getModuleName(packageContext.name, subpath) : undefined,
-    packageContext,
+    packagePath: packageContext.path,
     type: getModuleType(modulePath, packageContext.type, condition),
     fileName: basename(resolvedPath),
     relativePath: relative(packageContext.directory, resolvedPath),

--- a/src/utils/getCliArguments.ts
+++ b/src/utils/getCliArguments.ts
@@ -1,0 +1,83 @@
+import { stat } from 'node:fs/promises';
+import { basename, join, resolve } from 'node:path';
+import { Readable } from 'node:stream';
+import { parseArgs, type ParseArgsConfig } from 'node:util';
+
+import type { CliArguments } from '@src/types.js';
+
+import { parseConcurrency } from './parseConcurrency.js';
+
+async function resolvePackageJson(input: string): Promise<string> {
+  const stats = await stat(input);
+
+  if (stats.isDirectory()) {
+    return await resolvePackageJson(join(input, 'package.json'));
+  }
+
+  if (stats.isFile() && basename(input) === 'package.json') {
+    return resolve(input);
+  }
+
+  throw new Error(`Unable to resolve package.json from ${input}`);
+}
+
+export async function getCliArguments(): Promise<CliArguments> {
+  const config = {
+    allowPositionals: true,
+    strict: true,
+    tokens: false,
+    options: {
+      concurrency: {
+        type: 'string',
+        short: 'c',
+      },
+      // Stop processing at the first error.
+      bail: {
+        type: 'boolean',
+        short: 'b',
+        // Fail quickly if running in a CI service.
+        default: process.env.CI === 'true',
+      },
+      // Run syntax check
+      check: {
+        type: 'boolean',
+        default: false,
+        short: 's',
+      },
+      // Attempt to `import()` or `require()` the module.
+      verify: {
+        type: 'boolean',
+        default: false,
+        short: 'v',
+      },
+      // Output JSON
+      json: {
+        type: 'boolean',
+        default: false,
+        short: 'j',
+      },
+      // Show info messages
+      info: {
+        type: 'boolean',
+        default: process.env.RUNNER_DEBUG === '1',
+        short: 'i',
+      },
+    },
+  } satisfies ParseArgsConfig;
+
+  const { values, positionals } = parseArgs(config);
+
+  const packages = await Readable.from(positionals.length ? positionals : [join(process.cwd(), 'package.json')])
+    .map(packagePath => resolvePackageJson(packagePath))
+    .toArray();
+
+  return {
+    packages,
+    concurrency: parseConcurrency(values.concurrency),
+    bail: values.bail ?? config.options.bail.default,
+    check: values.check ?? config.options.check.default,
+    verify: values.verify ?? config.options.verify.default,
+    json: values.json ?? config.options.verify.default,
+    info: values.info ?? config.options.info.default,
+  };
+}

--- a/src/utils/getEntryPoints.ts
+++ b/src/utils/getEntryPoints.ts
@@ -1,4 +1,4 @@
-import type { EntryPoint, PackageJson } from '@src/types.js';
+import type { EntryPoint, PackageContext, PackageJson } from '@src/types.js';
 
 import { getEntryPointsFromBin } from './getEntryPointsFromBin.js';
 import { getEntryPointsFromBinDirectory } from './getEntryPointsFromBinDirectory.js';
@@ -8,12 +8,15 @@ import { getEntryPointsFromMain } from './getEntryPointsFromMain.js';
 import { getEntryPointsFromModule } from './getEntryPointsFromModule.js';
 import { getEntryPointsFromTypes } from './getEntryPointsFromTypes.js';
 
-export async function* getEntryPoints(packageJson: PackageJson, packageDirectory: string): AsyncGenerator<EntryPoint> {
-  yield* getEntryPointsFromBin(packageJson, packageDirectory);
-  yield* getEntryPointsFromBinDirectory(packageJson, packageDirectory);
-  yield* getEntryPointsFromBrowser(packageJson, packageDirectory);
-  yield* getEntryPointsFromMain(packageJson, packageDirectory);
-  yield* getEntryPointsFromModule(packageJson, packageDirectory);
-  yield* getEntryPointsFromTypes(packageJson, packageDirectory);
-  yield* getEntryPointsFromExports(packageJson, packageDirectory);
+export async function* getEntryPoints(
+  packageJson: PackageJson,
+  packageContext: PackageContext,
+): AsyncGenerator<EntryPoint> {
+  yield* getEntryPointsFromBin(packageJson, packageContext);
+  yield* getEntryPointsFromBinDirectory(packageJson, packageContext);
+  yield* getEntryPointsFromBrowser(packageJson, packageContext);
+  yield* getEntryPointsFromMain(packageJson, packageContext);
+  yield* getEntryPointsFromModule(packageJson, packageContext);
+  yield* getEntryPointsFromTypes(packageJson, packageContext);
+  yield* getEntryPointsFromExports(packageJson, packageContext);
 }

--- a/src/utils/getEntryPointsFromBin.ts
+++ b/src/utils/getEntryPointsFromBin.ts
@@ -1,18 +1,19 @@
-import type { EntryPoint, PackageJson } from '@src/types.js';
+import type { EntryPoint, PackageContext, PackageJson } from '@src/types.js';
 
 import { createEntryPoint } from './createEntryPoint.js';
 import { normalizeBin } from './normalizeBin.js';
 
-export function* getEntryPointsFromBin(packageJson: PackageJson, packageDirectory: string): Generator<EntryPoint> {
+export function* getEntryPointsFromBin(
+  packageJson: PackageJson,
+  packageContext: PackageContext,
+): Generator<EntryPoint> {
   if (packageJson.bin) {
     for (const [key, path] of Object.entries(normalizeBin(packageJson.bin, packageJson.name))) {
       yield createEntryPoint({
         condition: undefined,
         itemPath: typeof packageJson.bin === 'string' ? ['bin'] : ['bin', key],
         modulePath: path,
-        packageDirectory,
-        packageName: packageJson.name,
-        packageType: packageJson.type,
+        packageContext,
         subpath: undefined,
       });
     }

--- a/src/utils/getEntryPointsFromBinDirectory.ts
+++ b/src/utils/getEntryPointsFromBinDirectory.ts
@@ -1,13 +1,13 @@
 import { opendir } from 'node:fs/promises';
 
-import type { EntryPoint, PackageJson } from '@src/types.js';
+import type { EntryPoint, PackageContext, PackageJson } from '@src/types.js';
 
 import { createEntryPoint } from './createEntryPoint.js';
 import { resolveDirent } from './resolveDirent.js';
 
 export async function* getEntryPointsFromBinDirectory(
   packageJson: PackageJson,
-  packageDirectory: string,
+  packageContext: PackageContext,
 ): AsyncGenerator<EntryPoint> {
   if (typeof packageJson.directories?.bin === 'string') {
     const binDir = await opendir(packageJson.directories.bin);
@@ -18,9 +18,7 @@ export async function* getEntryPointsFromBinDirectory(
           condition: undefined,
           itemPath: ['directories', 'bin'],
           modulePath: resolveDirent(item),
-          packageDirectory,
-          packageName: packageJson.name,
-          packageType: packageJson.type,
+          packageContext,
           subpath: undefined,
         });
       }

--- a/src/utils/getEntryPointsFromBrowser.ts
+++ b/src/utils/getEntryPointsFromBrowser.ts
@@ -1,9 +1,12 @@
-import type { EntryPoint, PackageJson } from '@src/types.js';
+import type { EntryPoint, PackageContext, PackageJson } from '@src/types.js';
 import { isPackageBrowserRecord } from '@utils/type-predicate.js';
 
 import { createEntryPoint } from './createEntryPoint.js';
 
-export function* getEntryPointsFromBrowser(packageJson: PackageJson, packageDirectory: string): Generator<EntryPoint> {
+export function* getEntryPointsFromBrowser(
+  packageJson: PackageJson,
+  packageContext: PackageContext,
+): Generator<EntryPoint> {
   if (packageJson.browser) {
     if (isPackageBrowserRecord(packageJson.browser)) {
       const entries = Object.entries(packageJson.browser).filter(
@@ -15,9 +18,7 @@ export function* getEntryPointsFromBrowser(packageJson: PackageJson, packageDire
           condition: undefined,
           itemPath: ['browser', key],
           modulePath: value,
-          packageDirectory,
-          packageName: packageJson.name,
-          packageType: packageJson.type,
+          packageContext,
           subpath: undefined,
         });
       }
@@ -29,9 +30,7 @@ export function* getEntryPointsFromBrowser(packageJson: PackageJson, packageDire
       condition: undefined,
       itemPath: ['browser'],
       modulePath: packageJson.browser,
-      packageDirectory,
-      packageName: packageJson.name,
-      packageType: packageJson.type,
+      packageContext,
       subpath: undefined,
     });
   }

--- a/src/utils/getEntryPointsFromExports.test.ts
+++ b/src/utils/getEntryPointsFromExports.test.ts
@@ -14,7 +14,12 @@ describe('getEntryPointsFromExports()', () => {
             version: '123.456.789',
             exports: null,
           },
-          '/tmp',
+          {
+            name: 'example',
+            type: 'commonjs',
+            path: '/tmp/package.json',
+            directory: '/tmp',
+          },
         ),
       ).toArray();
 
@@ -37,7 +42,12 @@ describe('getEntryPointsFromExports()', () => {
               './package.json': './package.json',
             },
           },
-          '/tmp',
+          {
+            name: 'example',
+            type: 'commonjs',
+            path: '/tmp/package.json',
+            directory: '/tmp',
+          },
         ),
       ).toArray();
 

--- a/src/utils/getEntryPointsFromExports.ts
+++ b/src/utils/getEntryPointsFromExports.ts
@@ -1,19 +1,20 @@
 import { ExportsProcessor } from '@lib/ExportsProcessor.js';
-import type { EntryPoint, PackageJson } from '@src/types.js';
+import type { EntryPoint, PackageContext, PackageJson } from '@src/types.js';
 
 import { expandEntryPoint } from './expandEntryPoint.js';
 
 export async function* getEntryPointsFromExports(
   packageJson: PackageJson,
-  packageDirectory: string,
+  packageContext: PackageContext,
 ): AsyncGenerator<EntryPoint> {
   if (packageJson.exports) {
-    const entryPoints = new ExportsProcessor().process(packageJson.exports, {
-      packageType: packageJson.type ?? 'commonjs',
-      packageName: packageJson.name,
-      packageDirectory,
-      itemPath: ['exports'],
-    });
+    const entryPoints = new ExportsProcessor().process(
+      packageJson.exports,
+      {
+        itemPath: ['exports'],
+      },
+      packageContext,
+    );
 
     for (const entryPoint of entryPoints) {
       yield* expandEntryPoint(entryPoint);

--- a/src/utils/getEntryPointsFromMain.ts
+++ b/src/utils/getEntryPointsFromMain.ts
@@ -12,7 +12,7 @@ export function* getEntryPointsFromMain(
       itemPath: ['main'],
       modulePath: packageJson.main,
       packageContext,
-      subpath: '.',
+      subpath: undefined,
     });
   }
 }

--- a/src/utils/getEntryPointsFromMain.ts
+++ b/src/utils/getEntryPointsFromMain.ts
@@ -1,16 +1,17 @@
-import type { EntryPoint, PackageJson } from '@src/types.js';
+import type { EntryPoint, PackageContext, PackageJson } from '@src/types.js';
 
 import { createEntryPoint } from './createEntryPoint.js';
 
-export function* getEntryPointsFromMain(packageJson: PackageJson, packageDirectory: string): Generator<EntryPoint> {
+export function* getEntryPointsFromMain(
+  packageJson: PackageJson,
+  packageContext: PackageContext,
+): Generator<EntryPoint> {
   if (packageJson.main) {
     yield createEntryPoint({
       condition: undefined,
       itemPath: ['main'],
       modulePath: packageJson.main,
-      packageDirectory,
-      packageName: packageJson.name,
-      packageType: packageJson.type,
+      packageContext,
       subpath: '.',
     });
   }

--- a/src/utils/getEntryPointsFromModule.ts
+++ b/src/utils/getEntryPointsFromModule.ts
@@ -12,7 +12,7 @@ export function* getEntryPointsFromModule(
       itemPath: ['module'],
       modulePath: packageJson.module,
       packageContext,
-      subpath: '.',
+      subpath: undefined,
     });
   }
 }

--- a/src/utils/getEntryPointsFromModule.ts
+++ b/src/utils/getEntryPointsFromModule.ts
@@ -1,16 +1,17 @@
-import type { EntryPoint, PackageJson } from '@src/types.js';
+import type { EntryPoint, PackageContext, PackageJson } from '@src/types.js';
 
 import { createEntryPoint } from './createEntryPoint.js';
 
-export function* getEntryPointsFromModule(packageJson: PackageJson, packageDirectory: string): Generator<EntryPoint> {
+export function* getEntryPointsFromModule(
+  packageJson: PackageJson,
+  packageContext: PackageContext,
+): Generator<EntryPoint> {
   if (packageJson.module) {
     yield createEntryPoint({
       condition: undefined,
       itemPath: ['module'],
       modulePath: packageJson.module,
-      packageDirectory,
-      packageName: packageJson.name,
-      packageType: packageJson.type,
+      packageContext,
       subpath: '.',
     });
   }

--- a/src/utils/getEntryPointsFromTypes.ts
+++ b/src/utils/getEntryPointsFromTypes.ts
@@ -1,8 +1,11 @@
-import type { EntryPoint, PackageJson } from '@src/types.js';
+import type { EntryPoint, PackageContext, PackageJson } from '@src/types.js';
 
 import { createEntryPoint } from './createEntryPoint.js';
 
-export function* getEntryPointsFromTypes(packageJson: PackageJson, packageDirectory: string): Generator<EntryPoint> {
+export function* getEntryPointsFromTypes(
+  packageJson: PackageJson,
+  packageContext: PackageContext,
+): Generator<EntryPoint> {
   const typesProperty = 'types' in packageJson ? 'types' : 'typings' in packageJson ? 'typings' : undefined;
 
   if (typesProperty) {
@@ -13,9 +16,7 @@ export function* getEntryPointsFromTypes(packageJson: PackageJson, packageDirect
         condition: 'types',
         itemPath: [typesProperty],
         modulePath: types,
-        packageDirectory,
-        packageName: packageJson.name,
-        packageType: packageJson.type,
+        packageContext,
         subpath: undefined,
       });
     }

--- a/src/utils/parseLogLevel.test.ts
+++ b/src/utils/parseLogLevel.test.ts
@@ -6,14 +6,14 @@ import { parseLogLevel } from './parseLogLevel.js';
 
 describe('parseLogLevel()', () => {
   it('Returns a LogLevel', () => {
-    expect(parseLogLevel('warning')).toEqual(LogLevel.Warning);
-    expect(parseLogLevel(LogLevel.Warning)).toEqual(LogLevel.Warning);
+    expect(parseLogLevel('info')).toEqual(LogLevel.Info);
+    expect(parseLogLevel(LogLevel.Info, LogLevel.Warning)).toEqual(LogLevel.Info);
   });
 
   it.each(['bad input', Number.MAX_SAFE_INTEGER, undefined, true, false, null, [], {}])(
     'Returns default value when given "%s"',
     value => {
-      expect(parseLogLevel(value)).toEqual(LogLevel.Warning);
+      expect(parseLogLevel(value, LogLevel.Alert)).toEqual(LogLevel.Alert);
     },
   );
 });

--- a/src/utils/parseLogLevel.ts
+++ b/src/utils/parseLogLevel.ts
@@ -1,9 +1,9 @@
 import { LogLevel, logLevelMapping } from '@src/types.js';
 import { isLogLevel, isLogLevelName } from '@utils/type-predicate.js';
 
-export function parseLogLevel(input: unknown): LogLevel {
+export function parseLogLevel(input: unknown, defaultValue = LogLevel.Warning): LogLevel {
   if (typeof input === 'undefined') {
-    return LogLevel.Warning;
+    return defaultValue;
   }
 
   if (isLogLevel(input)) {
@@ -14,5 +14,5 @@ export function parseLogLevel(input: unknown): LogLevel {
     return logLevelMapping[input];
   }
 
-  return LogLevel.Warning;
+  return defaultValue;
 }

--- a/src/utils/verifyEntryPoint.ts
+++ b/src/utils/verifyEntryPoint.ts
@@ -1,4 +1,5 @@
-import { type EntryPoint, type Result } from '@src/types.js';
+import type { Result } from '@lib/Result.js';
+import type { EntryPoint } from '@src/types.js';
 
 import { checkImport } from './checkImport.js';
 import { checkRequire } from './checkRequire.js';


### PR DESCRIPTION
- Updated cli arguments and flags
  - Now accepts positional arguments for `package.json` file paths.
  
    Basic example: 

    ```sh
    validate-package-exports ./package.json
    ```

    If your shell supports it (works in `bash`), paths may get expanded.

    ```sh
    validate-package-exports ./packages/*
    ```

  - Added `--json`, `--info`
  - Removed `--logLevel` 